### PR TITLE
initialize controller type in constructor

### DIFF
--- a/src/TrajectoryFollowerTypes.hpp
+++ b/src/TrajectoryFollowerTypes.hpp
@@ -101,7 +101,8 @@ struct FollowerConfig
     bool usePoseErrorReachedEndCheck;
 
     FollowerConfig()
-        : dampingAngleUpperLimit(base::unset< double >()),
+        : controllerType(CONTROLLER_UNKNOWN),
+          dampingAngleUpperLimit(base::unset< double >()),
           maxRotationalVelocity(base::unset< double >()),
           pointTurnStart(base::unset< double >()),
           pointTurnEnd(base::unset< double >()),


### PR DESCRIPTION
makes component configuration and oroconf extract work in case the uninitialized value is not valid one
