### PR TITLE
Allow pointturn sidewalk for robots

### DIFF
--- a/src/Motion2D.hpp
+++ b/src/Motion2D.hpp
@@ -58,6 +58,7 @@ struct Motion2D {
         base::commands::Motion2D cmd;
         cmd.rotation = this->rotation;
         cmd.translation = this->translation;
+        cmd.heading = base::Angle::fromRad(this->heading);
         return cmd;
     }
     

--- a/src/TrajectoryFollower.cpp
+++ b/src/TrajectoryFollower.cpp
@@ -144,7 +144,7 @@ void TrajectoryFollower::computeErrors(const base::Pose& robotPose)
     followerData.splineSegmentEnd.position.head<2>() = splineEndPoint.position;
     followerData.splineSegmentStart.orientation = Eigen::Quaterniond(Eigen::AngleAxisd(splineStartPoint.orientation, Eigen::Vector3d::UnitZ()));
     followerData.splineSegmentEnd.orientation = Eigen::Quaterniond(Eigen::AngleAxisd(splineEndPoint.orientation, Eigen::Vector3d::UnitZ()));
-    
+
     currentCurveParameter = trajectory.posSpline.localClosestPointSearch(currentPose.position, splineSegmentGuessCurveParam, splineSegmentStartCurveParam, splineSegmentEndCurveParam);
     auto err = trajectory.error(currentPose.position.head<2>(), currentPose.getYaw(), currentCurveParameter);
     distanceError = err.first;
@@ -165,25 +165,26 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
     }
 
     /*
-        Here we need to differentiate whether the DriveMode::ModeTurnOnTheSpot is set by the 
+        Here we need to differentiate whether the DriveMode::ModeTurnOnTheSpot is set by the
         automatic point turn feature of trajectory follower or the DriveMode::ModeTurnOnTheSpot
-        is actually required by the planner as part of the planned trajectory 
-    */  
+        is actually required by the planner as part of the planned trajectory
+    */
 
-    if (trajectory.driveMode == DriveMode::ModeTurnOnTheSpot && automaticPointTurn == false) 
+    if (trajectory.driveMode == DriveMode::ModeTurnOnTheSpot && automaticPointTurn == false)
     {
         double actualHeading = robotPose.getYaw();
         double targetHeading = trajectory.goalPose.orientation;
 
         if (actualHeading < 0)
-            actualHeading = 2*M_PI + actualHeading; 
-
+            actualHeading = 2*M_PI + actualHeading;
+        if (targetHeading < 0)
+            targetHeading = 2*M_PI + targetHeading;
         double error       = actualHeading - targetHeading;
 
         Eigen::AngleAxisd currentAxisRot(actualHeading,Eigen::Vector3d::UnitZ());
         Eigen::AngleAxisd targetAxisRot(targetHeading,Eigen::Vector3d::UnitZ());
         Eigen::Vector3d currentRot = currentAxisRot * Eigen::Vector3d::UnitX();
-        Eigen::Vector3d desiredRot = targetAxisRot  * Eigen::Vector3d::UnitX();  
+        Eigen::Vector3d desiredRot = targetAxisRot  * Eigen::Vector3d::UnitX();
         Eigen::Vector3d cross      = currentRot.cross(desiredRot).normalized();
 
         followerStatus        = EXEC_TURN_ON_SPOT;
@@ -306,8 +307,8 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
 
         followerData.cmd = motionCmd.toBaseMotion2D();
         return followerStatus;
-    } 
-    
+    }
+
     motionCmd = controller->update(trajectory.getSpeed(), distanceError, angleError, trajectory.getCurvature(currentCurveParameter),
                                    trajectory.getVariationOfCurvature(currentCurveParameter));
 

--- a/src/TrajectoryFollower.cpp
+++ b/src/TrajectoryFollower.cpp
@@ -99,12 +99,8 @@ void TrajectoryFollower::computeErrors(const base::Pose& robotPose)
     lastPose = currentPose;
     currentPose = robotPose;
 
-    std::cout << "Current Position: " << currentPose.position.x() << " " <<currentPose.position.y() << std::endl;
-
     // Gets the heading of the current pose
     double currentHeading = currentPose.getYaw();
-
-    std::cout << "Current Heading: " << currentPose.getYaw() << std::endl;
 
     // Change heading based on direction of motion
     if(!trajectory.driveForward())
@@ -140,16 +136,9 @@ void TrajectoryFollower::computeErrors(const base::Pose& robotPose)
     splineSegmentEndCurveParam = trajectory.advance(currentCurveParameter, forwardLength);
     splineSegmentGuessCurveParam = trajectory.advance(currentCurveParameter, dist);
 
-    std::cout <<"Updating spline information for FollowerData" << std::endl;
-
     base::Pose2D splineStartPoint, splineEndPoint;
     splineStartPoint = trajectory.getIntermediatePoint(splineSegmentStartCurveParam);
     splineEndPoint = trajectory.getIntermediatePoint(splineSegmentEndCurveParam);
-
-    std::cout <<"Calculated spline start and end points" << std::endl;
-
-    std::cout <<"Spline start: " << splineStartPoint.position.x() << " " << splineStartPoint.position.y() << std::endl;
-    std::cout <<"Spline end: " << splineEndPoint.position.x() << " " << splineEndPoint.position.y() << std::endl;  
 
     followerData.splineSegmentStart.position.head<2>() = splineStartPoint.position;
     followerData.splineSegmentEnd.position.head<2>() = splineEndPoint.position;
@@ -157,15 +146,10 @@ void TrajectoryFollower::computeErrors(const base::Pose& robotPose)
     followerData.splineSegmentEnd.orientation = Eigen::Quaterniond(Eigen::AngleAxisd(splineEndPoint.orientation, Eigen::Vector3d::UnitZ()));
     
     currentCurveParameter = trajectory.posSpline.localClosestPointSearch(currentPose.position, splineSegmentGuessCurveParam, splineSegmentStartCurveParam, splineSegmentEndCurveParam);
-    std::cout << "Calculated current curver parameter " << std::endl;
     auto err = trajectory.error(currentPose.position.head<2>(), currentPose.getYaw(), currentCurveParameter);
-    std::cout << "Calculated error " << std::endl;
     distanceError = err.first;
     lastAngleError = angleError;
     angleError = err.second;
-
-    std::cout << "Angle Error " << angleError << std::endl;
-    std::cout << "Distance Error " << distanceError << std::endl;  
 }
 
 FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const base::Pose &robotPose)
@@ -179,7 +163,6 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
         LOG_INFO_S << "Trajectory follower not active";
         return followerStatus;
     }
-    std::cout << "Starting to traverse trajectory." << std::endl; 
 
     /*
         Here we need to differentiate whether the DriveMode::ModeTurnOnTheSpot is set by the 
@@ -218,7 +201,6 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
         }
         else
         {
-            std::cout << "Finished Point-turn" << std::endl;
             pointTurnDirection = 1.;
             followerStatus = TRAJECTORY_FINISHED;
             return followerStatus;
@@ -246,22 +228,16 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
             followerStatus = lastFollowerStatus;
         }
     }
-    std::cout << "Starting to compute errors " << std::endl;
     computeErrors(robotPose);
-    std::cout << "Computed errors " << std::endl;
 
     followerData.angleError = angleError;
     followerData.distanceError = distanceError;
-
-    std::cout << "Angle error: " << angleError << std::endl;
-    std::cout << "Distance error: " << distanceError << std::endl;
 
     followerData.currentPose.position = currentPose.position;
     followerData.currentPose.orientation = currentPose.orientation;
     base::Pose2D refPose = trajectory.getIntermediatePoint(currentCurveParameter);
     followerData.splineReference.position = Eigen::Vector3d(refPose.position.x(), refPose.position.y(), 0.);
     followerData.splineReference.orientation = Eigen::Quaterniond(Eigen::AngleAxisd(refPose.orientation, Eigen::Vector3d::UnitZ()));
-    std::cout << "Finished setting FollowerData" << std::endl;
 
     double distanceToEnd = trajectory.getDistToGoal(currentCurveParameter);
     lastPosError = posError;
@@ -312,7 +288,6 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
         }
         else
         {
-            std::cout << "stopped Point-Turn. Switching to normal controller" << std::endl;
             automaticPointTurn = false;
             pointTurnDirection = 1.;
             followerStatus = TRAJECTORY_FOLLOWING;

--- a/src/TrajectoryFollower.cpp
+++ b/src/TrajectoryFollower.cpp
@@ -195,13 +195,7 @@ FollowerStatus TrajectoryFollower::traverseTrajectory(Motion2D &motionCmd, const
         Eigen::Vector3d desiredRot = targetAxisRot  * Eigen::Vector3d::UnitX();  
         Eigen::Vector3d cross      = currentRot.cross(desiredRot).normalized();
 
-        std::cout << "Current Heading " << actualHeading << std::endl;
-        std::cout << "Goal Heading "    << targetHeading << std::endl;
-        std::cout << "Error  "          << error     << std::endl;
-
         followerStatus        = EXEC_TURN_ON_SPOT;
-
-        std::cout << "Cross.z " << cross.z() << std::endl;
 
         if (cross.z() == -1)
             pointTurnDirection = -1.;

--- a/src/TrajectoryFollower.hpp
+++ b/src/TrajectoryFollower.hpp
@@ -62,7 +62,7 @@ public:
 private:
     bool configured;
     ControllerType controllerType;
-    bool pointTurn;
+    bool automaticPointTurn;
     double pointTurnDirection;
     bool nearEnd;
     double dampingCoefficient;

--- a/src/TrajectoryFollower.hpp
+++ b/src/TrajectoryFollower.hpp
@@ -34,6 +34,12 @@ public:
     void setNewTrajectory(const SubTrajectory &trajectory, const base::Pose& robotPose);
 
     /**
+     * @brief Here we set the heading error tolerance for the orientation alignment for planner defined point-turns
+     * 
+     */
+    void setHeadingErrorTolerance(const double tolerance);
+
+    /**
      * Marks the current trajectory as traversed
      *
      * Stops the current trajectory following and removes the trajectory
@@ -64,6 +70,7 @@ private:
     ControllerType controllerType;
     bool automaticPointTurn;
     double pointTurnDirection;
+    double headingErrorTolerance;
     bool nearEnd;
     double dampingCoefficient;
     base::Pose currentPose;

--- a/src/TrajectoryFollowerTypes.hpp
+++ b/src/TrajectoryFollowerTypes.hpp
@@ -52,6 +52,7 @@ struct FollowerConfig
     double pointTurnStart; ///< Angle error at which point turn starts
     double pointTurnEnd;   ///< Angle error at which point turn, once started, stops
     double pointTurnVelocity; ///< Point turn velocity
+    double headingErrorTolerance; //Heading error tolerance for orientation alignment
     double geometricResolution; ///< Geometric resolution to be used
     double trajectoryFinishDistance; ///< Minimum distance to end point
     ///< of trajectory for considering it
@@ -69,6 +70,7 @@ struct FollowerConfig
           pointTurnStart(base::unset< double >()),
           pointTurnEnd(base::unset< double >()),
           pointTurnVelocity(base::unset< double >()),
+          headingErrorTolerance(0.05),
           geometricResolution(0.001),
           trajectoryFinishDistance(base::unset< double >()),
           splineReferenceError(base::unset< double >()),

--- a/viz/SubTrajectoryVisualization.cpp
+++ b/viz/SubTrajectoryVisualization.cpp
@@ -6,6 +6,7 @@
 #include <osg/LineWidth>
 
 using namespace vizkit3d;
+using trajectory_follower::DriveMode;
 
 struct SubTrajectoryVisualization::Data {
     std::vector<trajectory_follower::SubTrajectory> data;
@@ -13,7 +14,13 @@ struct SubTrajectoryVisualization::Data {
 
 
 SubTrajectoryVisualization::SubTrajectoryVisualization()
-    : p(new Data), line_width( 4.0 ), color(1., 1., 0., 1.), rescueColor(1., 0., 0., 1.)
+    : p(new Data)
+    , line_width( 4.0 )
+    , rescueColor(1., 0., 0., 1.)
+    , ackermannColor(1., 1., 0., 1.)
+    , turnOnTheSpotColor(1., 0., 1., 1.)
+    , sidewaysColor(0., 1., 0., 1.)
+    , diagonalColor(0., 1., 1., 1.)
 {
 }
 
@@ -45,9 +52,25 @@ void SubTrajectoryVisualization::updateMainNode ( osg::Node* node )
             osgPoints.emplace_back(splinePoint.x(), splinePoint.y(), splinePoint.z());
         }
         
-        osg::Vec4 currentColor = traj.kind == trajectory_follower::TRAJECTORY_KIND_RESCUE? rescueColor : color;
+        osg::Vec4 currentColor;
+        switch (traj.driveMode) {
+            case DriveMode::ModeAckermann:
+                currentColor = ackermannColor;
+                break;
+            case DriveMode::ModeTurnOnTheSpot:
+                currentColor = turnOnTheSpotColor;
+                break;
+            case DriveMode::ModeSideways:
+                currentColor = sidewaysColor;
+                break;
+            case DriveMode::ModeDiagonal:
+                currentColor = diagonalColor;
+                break;
+        }
+        if (traj.kind == trajectory_follower::TRAJECTORY_KIND_RESCUE)
+            currentColor = rescueColor;
         
-        auto prim = fac->createLinesNode(color, osgPoints);
+        auto prim = fac->createLinesNode(currentColor, osgPoints);
         geode->addChild(prim);
         
     }
@@ -66,9 +89,9 @@ void SubTrajectoryVisualization::updateDataIntern(std::vector<trajectory_followe
 
 void SubTrajectoryVisualization::setColor(QColor color)
 {
-    this->color = osg::Vec4(color.redF(), color.greenF(), color.blueF(), color.alphaF());
-    emit propertyChanged("Color");
-    setDirty();
+    // getColor and setColor currently have no real use as the trajectory is colored according
+    // to its drive mode and not in a single predefined color.
+    std::cerr << "Calling get/setColor() on SubTrajectoryVisualization is deprecated." << std::endl;
 }
 
 void SubTrajectoryVisualization::setRescueColor(QColor color)
@@ -78,17 +101,74 @@ void SubTrajectoryVisualization::setRescueColor(QColor color)
     setDirty();
 }
 
+void SubTrajectoryVisualization::setAckermannColor(QColor color)
+{
+    this->ackermannColor = osg::Vec4(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    emit propertyChanged("AckermannColor");
+    setDirty();
+}
+
+void SubTrajectoryVisualization::setTurnOnTheSpotColor(QColor color)
+{
+    this->turnOnTheSpotColor = osg::Vec4(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    emit propertyChanged("TurnOnTheSpotColor");
+    setDirty();
+}
+
+void SubTrajectoryVisualization::setSidewaysColor(QColor color)
+{
+    this->sidewaysColor = osg::Vec4(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    emit propertyChanged("SidewaysColor");
+    setDirty();
+}
+
+void SubTrajectoryVisualization::setDiagonalColor(QColor color)
+{
+    this->diagonalColor = osg::Vec4(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    emit propertyChanged("DiagonalColor");
+    setDirty();
+}
+
 QColor SubTrajectoryVisualization::getColor() const
 {
-    QColor c;
-    c.setRgbF(color.x(), color.y(), color.z(), color.w());
-    return c;
+    // getColor and setColor currently have no real use as the trajectory is colored according
+    // to its drive mode and not in a single predefined color.
+    std::cerr << "Calling get/setColor() on SubTrajectoryVisualization is deprecated." << std::endl;
+    return QColor();
 }
 
 QColor SubTrajectoryVisualization::getRescueColor() const
 {
     QColor c;
     c.setRgbF(rescueColor.x(), rescueColor.y(), rescueColor.z(), rescueColor.w());
+    return c;
+}
+
+QColor SubTrajectoryVisualization::getAckermannColor() const
+{
+    QColor c;
+    c.setRgbF(ackermannColor.x(), ackermannColor.y(), ackermannColor.z(), ackermannColor.w());
+    return c;
+}
+
+QColor SubTrajectoryVisualization::getTurnOnTheSpotColor() const
+{
+    QColor c;
+    c.setRgbF(turnOnTheSpotColor.x(), turnOnTheSpotColor.y(), turnOnTheSpotColor.z(), turnOnTheSpotColor.w());
+    return c;
+}
+
+QColor SubTrajectoryVisualization::getSidewaysColor() const
+{
+    QColor c;
+    c.setRgbF(sidewaysColor.x(), sidewaysColor.y(), sidewaysColor.z(), sidewaysColor.w());
+    return c;
+}
+
+QColor SubTrajectoryVisualization::getDiagonalColor() const
+{
+    QColor c;
+    c.setRgbF(diagonalColor.x(), diagonalColor.y(), diagonalColor.z(), diagonalColor.w());
     return c;
 }
 
@@ -114,4 +194,3 @@ void SubTrajectoryVisualization::setLineWidth(double line_width)
 
 //Macro that makes this plugin loadable in ruby, this is optional.
 VizkitQtPlugin(SubTrajectoryVisualization)
-

--- a/viz/SubTrajectoryVisualization.hpp
+++ b/viz/SubTrajectoryVisualization.hpp
@@ -14,8 +14,11 @@ namespace vizkit3d
     Q_OBJECT
 
     Q_PROPERTY(double LineWidth READ getLineWidth WRITE setLineWidth)
-    Q_PROPERTY(QColor Color READ getColor WRITE setColor)
     Q_PROPERTY(QColor RescueColor READ getRescueColor WRITE setRescueColor)
+    Q_PROPERTY(QColor AckermannColor READ getAckermannColor WRITE setAckermannColor)
+    Q_PROPERTY(QColor TurnOnTheSpotColor READ getTurnOnTheSpotColor WRITE setTurnOnTheSpotColor)
+    Q_PROPERTY(QColor SidewaysColor READ getSidewaysColor WRITE setSidewaysColor)
+    Q_PROPERTY(QColor DiagonalColor READ getDiagonalColor WRITE setDiagonalColor)
 
     public:
         SubTrajectoryVisualization();
@@ -31,7 +34,14 @@ namespace vizkit3d
         QColor getColor() const;
         void setRescueColor(QColor color);
         QColor getRescueColor() const;
-        
+        void setAckermannColor(QColor color);
+        QColor getAckermannColor() const;
+        void setTurnOnTheSpotColor(QColor color);
+        QColor getTurnOnTheSpotColor() const;
+        void setSidewaysColor(QColor color);
+        QColor getSidewaysColor() const;
+        void setDiagonalColor(QColor color);
+        QColor getDiagonalColor() const;
 
     protected:
         virtual osg::ref_ptr<osg::Node> createMainNode();
@@ -43,8 +53,11 @@ namespace vizkit3d
         Data* p;
 
         double line_width;
-        osg::Vec4 color;       
-        osg::Vec4 rescueColor;
+        osg::Vec4 rescueColor,
+            ackermannColor,
+            turnOnTheSpotColor,
+            sidewaysColor,
+            diagonalColor;
 
         osg::ref_ptr<osg::PositionAttitudeTransform> geode; 
     };


### PR DESCRIPTION
Hello,

this MR is long due. The changes from me add the capability to do pointturns and some earlier changes added the capability to do laterl movement (e.g. for artemis). Basically if the trajectory has DriveMode::ModeSideways and/or DriveMode::ModeTurnOnTheSpot then these cases are handled.

I must mention that there is a new config parameter `headingErrorTolerance` added to the  [FollowerConfig](https://github.com/rock-control/control-trajectory_follower/blob/eb96e3e3217c940a7f25ec8717b126fc9033cf60/src/TrajectoryFollowerTypes.hpp#L55). 

Best,
Haider